### PR TITLE
feat: add support for gpt5.

### DIFF
--- a/topicgpt_python/assignment.py
+++ b/topicgpt_python/assignment.py
@@ -199,7 +199,7 @@ def assign_topics(api, model, data, prompt_file, out_file, topic_file, verbose):
     - verbose (bool): Whether to print out results
     """
     api_client = APIClient(api=api, model=model)
-    max_tokens, temperature, top_p = 1000, 0.0, 1.0
+    max_tokens, temperature, top_p = 1000, 1.0, 1.0
 
     if verbose:
         print("-------------------")

--- a/topicgpt_python/correction.py
+++ b/topicgpt_python/correction.py
@@ -198,7 +198,7 @@ def correct_topics(
     - verbose: Print verbose output
     """
     api_client = APIClient(api=api, model=model)
-    max_tokens, temperature, top_p = 1000, 0.6, 0.9
+    max_tokens, temperature, top_p = 1000, 1.0, 0.9
     context_len = (
         128000
         if model not in ["gpt-3.5-turbo", "gpt-4"]

--- a/topicgpt_python/generation_1.py
+++ b/topicgpt_python/generation_1.py
@@ -170,7 +170,7 @@ def generate_topic_lvl1(
     - topics_root (TopicTree): Root node of the topic tree
     """
     api_client = APIClient(api=api, model=model)
-    max_tokens, temperature, top_p = 1000, 0.0, 1.0
+    max_tokens, temperature, top_p = 1000, 1.0, 1.0
 
     if verbose:
         print("-------------------")

--- a/topicgpt_python/generation_2.py
+++ b/topicgpt_python/generation_2.py
@@ -254,7 +254,7 @@ def generate_topic_lvl2(
     Returns: Root node of the topic tree
     """
     api_client = APIClient(api=api, model=model)
-    max_tokens, temperature, top_p = 1000, 0.0, 1.0
+    max_tokens, temperature, top_p = 1000, 1.0, 1.0
 
     if verbose:
         print("-------------------")

--- a/topicgpt_python/refinement.py
+++ b/topicgpt_python/refinement.py
@@ -261,7 +261,7 @@ def refine_topics(
     - None
     """
     api_client = APIClient(api=api, model=model)
-    max_tokens, temperature, top_p = 1000, 0.0, 1.0
+    max_tokens, temperature, top_p = 1000, 1.0, 1.0
     topics_root = TopicTree().from_topic_list(topic_file, from_file=True)
     if verbose:
         print("-------------------")

--- a/topicgpt_python/utils.py
+++ b/topicgpt_python/utils.py
@@ -159,7 +159,7 @@ class APIClient:
                     completion = self.client.chat.completions.create(
                         model=self.model,
                         messages=message,
-                        max_tokens=max_tokens,
+                        max_completion_tokens=max_tokens,
                         temperature=temperature,
                         top_p=top_p,
                     )


### PR DESCRIPTION
✨ Feature: Support for New GPT-5 Models

This Pull Request introduces full compatibility with OpenAI's new model series: gpt-5 and gpt-5-mini.

This upgrade is essential as the latest models use a revised API schema, making them incompatible with the current version of TopicGPT.

⚙️ Technical Changes
The primary changes address necessary parameter updates to correctly invoke the new gpt-5 models:

1. **Renamed Max Tokens Parameter:**

- The max_tokens argument is deprecated and no longer supported when invoking the gpt-5 series.

- Action: I have globally replaced instances of max_tokens with the new, required parameter: max_completion_tokens.

2. Adjusted Temperature Default:

- The gpt-5 model series is designed to accept a default temperature value of 1.0.

- Action: I have updated all relevant model invocation code to explicitly set the temperature to 1.0 to ensure optimal and consistent model behavior.

💡 Future Improvement (Follow-up Task)
While the current implementation hardcodes the temperature to 1.0, it would significantly improve the user experience to make this configurable.

Proposal: I suggest creating a follow-up issue (which I am happy to open) to refactor the temperature parameter. This would involve moving it to a configurable setting (e.g., via environment variables or a configuration file) to allow users to easily adjust the model's temperature without modifying the codebase.

✅ Testing Notes
I have verified successful completion calls using the following models: `gpt-4o`, `gpt-4o-mini`, `gpt-5`, `gpt-5-mini`, as well as Ollama models, including `gemma3:latest` and `llama3.1:latest`.